### PR TITLE
Refactor validate unclaimed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1492,7 +1492,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/frontier.git#ee8c5b4a0ed24bcc2fa794070e443abbdbc4d6a6"
+source = "git+https://github.com/paritytech/frontier#ee8c5b4a0ed24bcc2fa794070e443abbdbc4d6a6"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -1518,7 +1518,7 @@ dependencies = [
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/frontier.git#ee8c5b4a0ed24bcc2fa794070e443abbdbc4d6a6"
+source = "git+https://github.com/paritytech/frontier#ee8c5b4a0ed24bcc2fa794070e443abbdbc4d6a6"
 dependencies = [
  "fp-storage",
  "kvdb",
@@ -1533,7 +1533,7 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/frontier.git#ee8c5b4a0ed24bcc2fa794070e443abbdbc4d6a6"
+source = "git+https://github.com/paritytech/frontier#ee8c5b4a0ed24bcc2fa794070e443abbdbc4d6a6"
 dependencies = [
  "fc-consensus",
  "fc-db",
@@ -1551,7 +1551,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/frontier.git#ee8c5b4a0ed24bcc2fa794070e443abbdbc4d6a6"
+source = "git+https://github.com/paritytech/frontier#ee8c5b4a0ed24bcc2fa794070e443abbdbc4d6a6"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -1596,7 +1596,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/paritytech/frontier.git#ee8c5b4a0ed24bcc2fa794070e443abbdbc4d6a6"
+source = "git+https://github.com/paritytech/frontier#ee8c5b4a0ed24bcc2fa794070e443abbdbc4d6a6"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -1704,7 +1704,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/frontier.git#ee8c5b4a0ed24bcc2fa794070e443abbdbc4d6a6"
+source = "git+https://github.com/paritytech/frontier#ee8c5b4a0ed24bcc2fa794070e443abbdbc4d6a6"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -1718,7 +1718,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/paritytech/frontier.git#ee8c5b4a0ed24bcc2fa794070e443abbdbc4d6a6"
+source = "git+https://github.com/paritytech/frontier#ee8c5b4a0ed24bcc2fa794070e443abbdbc4d6a6"
 dependencies = [
  "evm",
  "parity-scale-codec",
@@ -1730,7 +1730,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/paritytech/frontier.git#ee8c5b4a0ed24bcc2fa794070e443abbdbc4d6a6"
+source = "git+https://github.com/paritytech/frontier#ee8c5b4a0ed24bcc2fa794070e443abbdbc4d6a6"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -1747,7 +1747,7 @@ dependencies = [
 [[package]]
 name = "fp-self-contained"
 version = "1.0.0-dev"
-source = "git+https://github.com/paritytech/frontier.git#ee8c5b4a0ed24bcc2fa794070e443abbdbc4d6a6"
+source = "git+https://github.com/paritytech/frontier#ee8c5b4a0ed24bcc2fa794070e443abbdbc4d6a6"
 dependencies = [
  "ethereum",
  "frame-support",
@@ -1764,7 +1764,7 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/frontier.git#ee8c5b4a0ed24bcc2fa794070e443abbdbc4d6a6"
+source = "git+https://github.com/paritytech/frontier#ee8c5b4a0ed24bcc2fa794070e443abbdbc4d6a6"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -4284,7 +4284,7 @@ dependencies = [
 [[package]]
 name = "pallet-base-fee"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/frontier.git#ee8c5b4a0ed24bcc2fa794070e443abbdbc4d6a6"
+source = "git+https://github.com/paritytech/frontier#ee8c5b4a0ed24bcc2fa794070e443abbdbc4d6a6"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4316,7 +4316,7 @@ dependencies = [
 [[package]]
 name = "pallet-dynamic-fee"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/frontier.git#ee8c5b4a0ed24bcc2fa794070e443abbdbc4d6a6"
+source = "git+https://github.com/paritytech/frontier#ee8c5b4a0ed24bcc2fa794070e443abbdbc4d6a6"
 dependencies = [
  "async-trait",
  "frame-support",
@@ -4334,7 +4334,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/frontier.git#ee8c5b4a0ed24bcc2fa794070e443abbdbc4d6a6"
+source = "git+https://github.com/paritytech/frontier#ee8c5b4a0ed24bcc2fa794070e443abbdbc4d6a6"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4363,7 +4363,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/paritytech/frontier.git#ee8c5b4a0ed24bcc2fa794070e443abbdbc4d6a6"
+source = "git+https://github.com/paritytech/frontier#ee8c5b4a0ed24bcc2fa794070e443abbdbc4d6a6"
 dependencies = [
  "evm",
  "evm-gasometer",
@@ -4391,7 +4391,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/frontier.git#ee8c5b4a0ed24bcc2fa794070e443abbdbc4d6a6"
+source = "git+https://github.com/paritytech/frontier#ee8c5b4a0ed24bcc2fa794070e443abbdbc4d6a6"
 dependencies = [
  "fp-evm",
  "num",
@@ -4402,7 +4402,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/frontier.git#ee8c5b4a0ed24bcc2fa794070e443abbdbc4d6a6"
+source = "git+https://github.com/paritytech/frontier#ee8c5b4a0ed24bcc2fa794070e443abbdbc4d6a6"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -4413,7 +4413,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/frontier.git#ee8c5b4a0ed24bcc2fa794070e443abbdbc4d6a6"
+source = "git+https://github.com/paritytech/frontier#ee8c5b4a0ed24bcc2fa794070e443abbdbc4d6a6"
 dependencies = [
  "fp-evm",
  "ripemd160",

--- a/pallets/airdrop/src/mock.rs
+++ b/pallets/airdrop/src/mock.rs
@@ -1,7 +1,5 @@
-use core::marker::PhantomData;
-
-use crate::types::MerkelProofValidator;
 use crate::{self as pallet_airdrop, types};
+use core::marker::PhantomData;
 
 use frame_support::{parameter_types, traits::ConstU32};
 use frame_system as system;
@@ -89,9 +87,7 @@ impl pallet_airdrop::Config for Test {
 	type VerifiableAccountId = AccountId;
 	type Currency = Balances;
 	type FetchIconEndpoint = FetchIconEndpoint;
-	// type AuthorityId = crate::airdrop_crypto::AuthId;
 	type Creditor = CreditorAccount;
-	type VestingModule = Test;
 	type BalanceTypeConversion = sp_runtime::traits::ConvertInto;
 	type AirdropWeightInfo = pallet_airdrop::weights::AirDropWeightInfo<Test>;
 	type MerkelProofValidator = TestValidator<Test>;

--- a/pallets/airdrop/src/tests/utility_functions.rs
+++ b/pallets/airdrop/src/tests/utility_functions.rs
@@ -468,3 +468,51 @@ fn validate_creditor_fund() {
 		}
 	});
 }
+
+#[test]
+fn ensure_claimable_snapshot() {
+	minimal_test_ext().execute_with(|| {
+		// Fail when both are claimed
+		{
+			let snapshot = types::SnapshotInfo::<Test> {
+				done_instant: true,
+				done_vesting: true,
+				..Default::default()
+			};
+			assert_err!(
+				AirdropModule::ensure_claimable(&snapshot),
+				PalletError::ClaimAlreadyMade
+			);
+		}
+
+		// Pass when both are not done
+		{
+			let snapshot = types::SnapshotInfo::<Test> {
+				done_instant: false,
+				done_vesting: false,
+				..Default::default()
+			};
+			assert_ok!(AirdropModule::ensure_claimable(&snapshot));
+		}
+
+		// Pass when vesting is not claimed
+		{
+			let snapshot = types::SnapshotInfo::<Test> {
+				done_instant: false,
+				done_vesting: true,
+				..Default::default()
+			};
+			assert_ok!(AirdropModule::ensure_claimable(&snapshot));
+		}
+
+		// Pass when instant is not claimed
+		{
+			let snapshot = types::SnapshotInfo::<Test> {
+				done_instant: true,
+				done_vesting: false,
+				..Default::default()
+			};
+			assert_ok!(AirdropModule::ensure_claimable(&snapshot));
+		}
+	});
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -256,12 +256,7 @@ impl pallet_airdrop::Config for Runtime {
 	type Event = Event;
 	type Currency = Balances;
 	type FetchIconEndpoint = AirdropFetchIconEndpoint;
-	// TODO:
-	// Ensure that using app_crypto! generated pairs are safe to use
-	// Also ensure effect of (not)enabling full-crypto feature
-	// type AuthorityId = pallet_airdrop::airdrop_crypto::AuthId;
 	type Creditor = AirdropCreditor;
-	type VestingModule = Runtime;
 	type BalanceTypeConversion = sp_runtime::traits::ConvertInto;
 	type AirdropWeightInfo = pallet_airdrop::weights::AirDropWeightInfo<Runtime>;
 


### PR DESCRIPTION
Changes:
- Previously validate_unclaimed did checks and write at single call. Now, they are splitted into `get_or_insert_address` & `ensure_claimable`
- We probably do not need two separate version of `validate_unclaimed`
- added test