### PR TITLE
Check if vesting amount is >= MinVestingAmount

### DIFF
--- a/pallets/airdrop/src/tests/exchange_claim.rs
+++ b/pallets/airdrop/src/tests/exchange_claim.rs
@@ -19,7 +19,7 @@ fn claim_success() {
 		let icon_wallet = VALID_ICON_WALLET;
 		let ice_address =
 			hex_literal::hex!("da8db20713c087e12abae13f522693299b9de1b70ff0464caa5d392396a8f76c");
-		let ice_address = AirdropModule::to_account_id(ice_address.clone()).unwrap();
+		let ice_address = AirdropModule::convert_to_account_id(ice_address.clone()).unwrap();
 
 		pallet_airdrop::ExchangeAccountsMap::<Test>::insert(icon_wallet, amount);
 		set_creditor_balance(10_000_0000);
@@ -139,7 +139,7 @@ fn already_claimed() {
 		let icon_wallet = VALID_ICON_WALLET;
 		let ice_address =
 			hex_literal::hex!("da8db20713c087e12abae13f522693299b9de1b70ff0464caa5d392396a8f76c");
-		let ice_account = AirdropModule::to_account_id(ice_address).unwrap();
+		let ice_account = AirdropModule::convert_to_account_id(ice_address).unwrap();
 
 		let mut snapshot = types::SnapshotInfo::default().ice_address(ice_account.clone());
 		snapshot.done_instant = true;

--- a/pallets/airdrop/src/tests/mock.rs
+++ b/pallets/airdrop/src/tests/mock.rs
@@ -76,7 +76,7 @@ impl system::Config for Test {
 parameter_types! {
 	pub const ExistentialDeposit: u128 = 500;
 	pub const MaxLocks: u32 = 50;
-	pub const VestingMinTransfer: Balance = 10_000;
+	pub const VestingMinTransfer: Balance = 1000;
 }
 
 impl pallet_airdrop::Config for Test {

--- a/pallets/airdrop/src/tests/utility_functions.rs
+++ b/pallets/airdrop/src/tests/utility_functions.rs
@@ -62,19 +62,12 @@ fn ensure_root_or_server() {
 }
 
 #[test]
-<<<<<<< HEAD
 fn get_vesting_amounts_splitted() {
 	use sp_runtime::ArithmeticError;
 	let expected_defi_instant_per=40;
     let expected_non_defi_instant_per=30;
     minimal_test_ext().execute_with(|| {
-		let get_splitted_amounts: _ = utils::get_splitted_amounts::<Test>;
-=======
-fn get_vesting_amounts_split() {
-	minimal_test_ext().execute_with(|| {
-		use sp_runtime::ArithmeticError;
 		let get_split_amounts: _ = utils::get_split_amounts::<Test>;
->>>>>>> upstream-main
 		let defi_instant = utils::get_instant_percentage::<Test>(true);
 		let non_defi_instant = utils::get_instant_percentage::<Test>(false);
 
@@ -87,25 +80,20 @@ fn get_vesting_amounts_split() {
 			ArithmeticError::Overflow
 		);
 		assert_eq!(
-<<<<<<< HEAD
 			Ok((10_u32.into(), 0u32.into())),
-			get_splitted_amounts(10, 100)
-=======
-			Ok((0_u32.into(), 0_u32.into())),
-			get_split_amounts(0_u32.into(), defi_instant)
->>>>>>> upstream-main
+			get_split_amounts(10, 100)
 		);
         assert_eq!(
             Ok((0u32.into(), 10u32.into())),
-            get_splitted_amounts(10, 0)
+            get_split_amounts(10, 0)
         );
         assert_eq!(
             Ok((0u32.into(), 0u32.into())),
-            get_splitted_amounts(0, 50)
+            get_split_amounts(0, 50)
         );
         assert_eq!(
             Ok((0u32.into(), 0u32.into())),
-            get_splitted_amounts(0, 0)
+            get_split_amounts(0, 0)
         );
 
 		assert_eq!(
@@ -117,19 +105,6 @@ fn get_vesting_amounts_split() {
 			Ok((1200_u32.into(), 1800_u32.into())),
 			get_split_amounts(3_000_u32.into(), defi_instant)
 		);
-<<<<<<< HEAD
-=======
-
-		assert_eq!(
-			Ok((0_u32.into(), 1_u32.into())),
-			get_split_amounts(1_u32.into(), non_defi_instant)
-		);
-		assert_eq!(
-			Ok((0_u32.into(), 1_u32.into())),
-			get_split_amounts(1_u32.into(), defi_instant)
-		);
-
->>>>>>> upstream-main
 		assert_eq!(
 			Ok((2932538_u32.into(), 6842591_u32.into())),
 			get_split_amounts(9775129_u32.into(), non_defi_instant)
@@ -147,7 +122,7 @@ fn get_vesting_amounts_splitted_no_vesting() {
 	use sp_runtime::ArithmeticError;
    
     minimal_test_ext().execute_with(|| {
-		let get_splitted_amounts: _ = utils::get_splitted_amounts::<Test>;
+		let get_splitted_amounts: _ = utils::get_split_amounts::<Test>;
 		let defi_instant = 100;
 		let non_defi_instant = 100;
 		assert_eq!(
@@ -191,17 +166,26 @@ fn cook_vesting_schedule() {
 	minimal_test_ext().execute_with(|| {
 		{
 			let (schedule, remainder) =
-				utils::new_vesting_with_deadline::<Test, 0u32>(10u32.into(), 10u32.into());
+				utils::new_vesting_with_deadline::<Test, 0u32>(1000u32.into(), 1000u32.into());
 
 			let schedule = schedule.unwrap();
 			assert_eq!(remainder, 0u32.into());
 
-			assert_eq!(schedule.locked(), 10u32.into());
+			assert_eq!(schedule.locked(), 1000u32.into());
 			assert_eq!(schedule.per_block(), 1u32.into());
 			assert_eq!(
 				schedule.ending_block_as_balance::<BlockToBalance>(),
-				10u32.into()
+				1000u32.into()
 			);
+		}
+
+		{
+			let min_vesting_amount = <Test as pallet_vesting::Config>::MinVestedTransfer::get();
+			let amount = min_vesting_amount - 1;
+			let (schedule, remainder) = utils::new_vesting_with_deadline::<Test, 0u32>(amount, 1);
+
+			assert_eq!(schedule, None);
+			assert_eq!(remainder, amount);
 		}
 
 		{
@@ -214,13 +198,13 @@ fn cook_vesting_schedule() {
 
 		{
 			let (schedule, remained) =
-				utils::new_vesting_with_deadline::<Test, 5u32>(12u32.into(), 10u32.into());
+				utils::new_vesting_with_deadline::<Test, 5u32>(1002u32.into(), 10u32.into());
 
 			let primary = schedule.unwrap();
 			assert_eq!(remained, 2u32.into());
 
-			assert_eq!(primary.locked(), 10u32.into());
-			assert_eq!(primary.per_block(), 2u32.into());
+			assert_eq!(primary.locked(), 1000u32.into());
+			assert_eq!(primary.per_block(), 200u32.into());
 			assert_eq!(
 				primary.ending_block_as_balance::<BlockToBalance>(),
 				10u32.into()
@@ -229,13 +213,13 @@ fn cook_vesting_schedule() {
 
 		{
 			let (schedule, remained) =
-				utils::new_vesting_with_deadline::<Test, 0u32>(16u32.into(), 10u32.into());
+				utils::new_vesting_with_deadline::<Test, 0u32>(1006_u32.into(), 10u32.into());
 
 			let schedule = schedule.unwrap();
 			assert_eq!(remained, 6u32.into());
 
-			assert_eq!(schedule.locked(), 10u32.into());
-			assert_eq!(schedule.per_block(), 1u32.into());
+			assert_eq!(schedule.locked(), 1000_u32.into());
+			assert_eq!(schedule.per_block(), 100_u32.into());
 			assert_eq!(
 				schedule.ending_block_as_balance::<BlockToBalance>(),
 				10u32.into()

--- a/pallets/airdrop/src/transfer.rs
+++ b/pallets/airdrop/src/transfer.rs
@@ -18,7 +18,7 @@ pub fn do_transfer<T: airdrop::Config>(snapshot: &mut types::SnapshotInfo<T>) ->
 
 	let instant_percentage = utils::get_instant_percentage::<T>(defi_user);
 	let (mut instant_amount, vesting_amount) =
-			utils::get_splitted_amounts::<T>(total_amount, instant_percentage).map_err(|e |{
+			utils::get_split_amounts::<T>(total_amount, instant_percentage).map_err(|e |{
 				error!("At: get_splitted_amount. amount: {total_amount:?}. Instant percentage: {instant_percentage}. Reason: {e:?}");
 				e
 			})?;


### PR DESCRIPTION
- While creating vesting scheule, we check if amount is greater or equal to `MinVestingTransfer` defined in `pallet_vesting`. 
- This will make sure when this schedule is applied in intended condition, it will not fail due to `AmountLow` error